### PR TITLE
[android][calendar] add `EventRecurrenceUtils` unit tests

### DIFF
--- a/packages/expo-calendar/CHANGELOG.md
+++ b/packages/expo-calendar/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### 💡 Others
 
+- [android][calendar] add `EventRecurrenceUtils` unit tests ([#33863](https://github.com/expo/expo/pull/33863) by [@mateoguzmana](https://github.com/mateoguzmana))
 - [ios][calendar] Use EXPermissionStatus instead of CalendarPermissionsStatus in calendar permissions requesters ([#33453](https://github.com/expo/expo/pull/33453) by [@ryanduffin](https://github.com/ryanduffin)
 
 ## 14.0.4 - 2024-11-29

--- a/packages/expo-calendar/android/build.gradle
+++ b/packages/expo-calendar/android/build.gradle
@@ -21,4 +21,7 @@ android {
 dependencies {
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1")
+
+  testImplementation 'junit:junit:4.13.2'
+  testImplementation 'io.mockk:mockk:1.13.5'
 }

--- a/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceUtilsTest.kt
+++ b/packages/expo-calendar/android/src/test/java/expo/modules/calendar/EventRecurrenceUtilsTest.kt
@@ -1,0 +1,99 @@
+package expo.modules.calendar
+
+import expo.modules.core.arguments.ReadableArguments
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class EventRecurrenceUtilsTest {
+
+  @Test
+  fun testExtractRecurrence_withAllFields() {
+    val mockArgs = mockk<ReadableArguments>(relaxed = true)
+
+    every { mockArgs.getString("frequency") } returns "daily"
+    every { mockArgs.getInt("interval") } returns 2
+    every { mockArgs.containsKey("interval") } returns true
+    every { mockArgs.getInt("occurrence") } returns 10
+    every { mockArgs.containsKey("occurrence") } returns true
+    every { mockArgs["endDate"] } returns "2024-12-31T00:00:00.000Z"
+    every { mockArgs.containsKey("endDate") } returns true
+
+    val result = EventRecurrenceUtils.extractRecurrence(mockArgs)
+
+    assertEquals("daily", result.frequency)
+    assertEquals(2, result.interval)
+    assertEquals("20241231T010000Z", result.endDate)
+    assertEquals(10, result.occurrence)
+  }
+
+  @Test
+  fun testExtractRecurrence_withMissingOptionalFields() {
+    val mockArgs = mockk<ReadableArguments>(relaxed = true)
+
+    every { mockArgs.getString("frequency") } returns "weekly"
+    every { mockArgs.containsKey("interval") } returns false
+    every { mockArgs.containsKey("occurrence") } returns false
+    every { mockArgs.containsKey("endDate") } returns false
+
+    val result = EventRecurrenceUtils.extractRecurrence(mockArgs)
+
+    assertEquals("weekly", result.frequency)
+    assertNull(result.interval)
+    assertNull(result.endDate)
+    assertNull(result.occurrence)
+  }
+
+  @Test
+  fun testExtractRecurrence_withNullEndDate() {
+    val mockArgs = mockk<ReadableArguments>(relaxed = true)
+
+    every { mockArgs.getString("frequency") } returns "yearly"
+    every { mockArgs.getInt("interval") } returns 1
+    every { mockArgs.containsKey("interval") } returns true
+    every { mockArgs["endDate"] } returns null
+    every { mockArgs.containsKey("endDate") } returns true
+
+    val result = EventRecurrenceUtils.extractRecurrence(mockArgs)
+
+    assertEquals("yearly", result.frequency)
+    assertEquals(1, result.interval)
+    assertNull(result.endDate)
+    assertNull(result.occurrence)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withAllFields() {
+    val opts =
+      Recurrence(
+        frequency = "daily",
+        interval = 1,
+        endDate = "20241231T010000Z",
+        occurrence = null
+      )
+
+    val result = EventRecurrenceUtils.createRecurrenceRule(opts)
+
+    assertEquals("FREQ=DAILY;INTERVAL=1;UNTIL=20241231T010000Z", result)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withOccurrence() {
+    val opts = Recurrence(frequency = "weekly", interval = 2, endDate = null, occurrence = 10)
+
+    val result = EventRecurrenceUtils.createRecurrenceRule(opts)
+
+    assertEquals("FREQ=WEEKLY;INTERVAL=2;COUNT=10", result)
+  }
+
+  @Test
+  fun testCreateRecurrenceRule_withMissingOptionalFields() {
+    val opts = Recurrence(frequency = "monthly", interval = null, endDate = null, occurrence = null)
+
+    val result = EventRecurrenceUtils.createRecurrenceRule(opts)
+
+    assertEquals("FREQ=MONTHLY", result)
+  }
+}


### PR DESCRIPTION
# Why

While navigating the internals, I saw an opportunity to improve the testing for some packages to reduce the likelihood of errors in future changes. Currently, the `expo-calendar` module lacks unit tests for its native Android implementation.

# How

This PR introduces unit tests for `EventRecurrenceUtils` to validate its outputs and ensure correctness. Additionally, it updates the package's `build.gradle` file to include the necessary testing dependencies, laying the groundwork for expanding test coverage in the future.

# Test Plan

```bash
yarn et native-unit-tests --platform android --packages expo-calendar
```

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
