### PR TITLE
[android][calendar] migrate `EventNotSavedException` to kotlin

### DIFF
--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/EventNotSavedException.java
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/EventNotSavedException.java
@@ -1,4 +1,0 @@
-package expo.modules.calendar;
-
-public class EventNotSavedException extends Exception {
-}

--- a/packages/expo-calendar/android/src/main/java/expo/modules/calendar/EventNotSavedException.kt
+++ b/packages/expo-calendar/android/src/main/java/expo/modules/calendar/EventNotSavedException.kt
@@ -1,0 +1,3 @@
+package expo.modules.calendar
+
+class EventNotSavedException : Exception()


### PR DESCRIPTION
# Why

All the `expo-calendar` codebase is already in Kotlin. Only this class is missing to be converted

# How

Convert from Java to Kotlin

# Test Plan

Made sure the module builds and the calendar still works as expected.

# Checklist

<!--
Please check the appropriate items below if they apply to your diff.
-->

- [ ] I added a `changelog.md` entry and rebuilt the package sources according to [this short guide](https://github.com/expo/expo/blob/main/CONTRIBUTING.md#-before-submitting)
- [ ] This diff will work correctly for `npx expo prebuild` & EAS Build (eg: updated a module plugin).
- [ ] Conforms with the [Documentation Writing Style Guide](https://github.com/expo/expo/blob/main/guides/Expo%20Documentation%20Writing%20Style%20Guide.md)
